### PR TITLE
Enabling AddOrgEntries when setting up DS 389 for the first time

### DIFF
--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -62,7 +62,7 @@ define ds_389::instance(
 ) {
   include ::ds_389
 
-  $setup_ds_base_opts = "--silent General.FullMachineName=${server_host} General.SuiteSpotGroup=${group} General.SuiteSpotUserID=${user} slapd.InstallLdifFile=none slapd.RootDN=\"${root_dn}\" slapd.RootDNPwd=${root_dn_pass} slapd.ServerIdentifier=${server_id} slapd.ServerPort=${server_port} slapd.Suffix=${suffix}"  # lint:ignore:140chars
+  $setup_ds_base_opts = "--silent General.FullMachineName=${server_host} General.SuiteSpotGroup=${group} General.SuiteSpotUserID=${user} slapd.AddOrgEntries=Yes slapd.AddSampleEntries=No slapd.InstallLdifFile=suggest slapd.RootDN=\"${root_dn}\" slapd.RootDNPwd=${root_dn_pass} slapd.ServerIdentifier=${server_id} slapd.ServerPort=${server_port} slapd.Suffix=${suffix}"  # lint:ignore:140chars
   $setup_ds_admin_base_opts = "--keepcache General.AdminDomain=${admin_domain} General.ConfigDirectoryAdminID=admin General.ConfigDirectoryAdminPwd=${root_dn_pass} admin.Port=${admin_port} admin.ServerAdminID=admin admin.ServerAdminPwd=${root_dn_pass} admin.ServerIpAddress=\"${admin_server_ip_address}\" admin.SysUser=${user}"  # lint:ignore:140chars
   $instance_path = "/etc/dirsrv/slapd-${server_id}"
   if $::ds_389::manage_admin {

--- a/spec/defines/instance_spec.rb
+++ b/spec/defines/instance_spec.rb
@@ -44,7 +44,7 @@ describe 'ds_389::instance' do
         when 'Debian'
           it {
             is_expected.to contain_exec('setup ds: specdirectory').with(
-              'command' => "setup-ds-admin --silent General.FullMachineName=foo.example.com General.SuiteSpotGroup=dirsrv General.SuiteSpotUserID=dirsrv slapd.InstallLdifFile=none slapd.RootDN=\"cn=Directory Manager\" slapd.RootDNPwd=supersecure slapd.ServerIdentifier=specdirectory slapd.ServerPort=389 slapd.Suffix=dc=example,dc=com --keepcache General.AdminDomain=#{os_facts[:domain]} General.ConfigDirectoryAdminID=admin General.ConfigDirectoryAdminPwd=supersecure admin.Port=9830 admin.ServerAdminID=admin admin.ServerAdminPwd=supersecure admin.ServerIpAddress=\"127.0.0.1\" admin.SysUser=dirsrv", # rubocop:disable LineLength
+              'command' => "setup-ds-admin --silent General.FullMachineName=foo.example.com General.SuiteSpotGroup=dirsrv General.SuiteSpotUserID=dirsrv slapd.AddOrgEntries=Yes slapd.AddSampleEntries=No slapd.InstallLdifFile=suggest slapd.RootDN=\"cn=Directory Manager\" slapd.RootDNPwd=supersecure slapd.ServerIdentifier=specdirectory slapd.ServerPort=389 slapd.Suffix=dc=example,dc=com --keepcache General.AdminDomain=#{os_facts[:domain]} General.ConfigDirectoryAdminID=admin General.ConfigDirectoryAdminPwd=supersecure admin.Port=9830 admin.ServerAdminID=admin admin.ServerAdminPwd=supersecure admin.ServerIpAddress=\"127.0.0.1\" admin.SysUser=dirsrv", # rubocop:disable LineLength
               'path'    => '/usr/sbin:/usr/bin:/sbin:/bin',
               'creates' => '/etc/dirsrv/slapd-specdirectory',
             )
@@ -95,7 +95,7 @@ describe 'ds_389::instance' do
         when 'RedHat'
           it {
             is_expected.to contain_exec('setup ds: specdirectory').with(
-              'command' => "setup-ds-admin.pl --silent General.FullMachineName=foo.example.com General.SuiteSpotGroup=dirsrv General.SuiteSpotUserID=dirsrv slapd.InstallLdifFile=none slapd.RootDN=\"cn=Directory Manager\" slapd.RootDNPwd=supersecure slapd.ServerIdentifier=specdirectory slapd.ServerPort=389 slapd.Suffix=dc=example,dc=com --keepcache General.AdminDomain=#{os_facts[:domain]} General.ConfigDirectoryAdminID=admin General.ConfigDirectoryAdminPwd=supersecure admin.Port=9830 admin.ServerAdminID=admin admin.ServerAdminPwd=supersecure admin.ServerIpAddress=\"127.0.0.1\" admin.SysUser=dirsrv", # rubocop:disable LineLength
+              'command' => "setup-ds-admin.pl --silent General.FullMachineName=foo.example.com General.SuiteSpotGroup=dirsrv General.SuiteSpotUserID=dirsrv slapd.AddOrgEntries=Yes slapd.AddSampleEntries=No slapd.InstallLdifFile=suggest slapd.RootDN=\"cn=Directory Manager\" slapd.RootDNPwd=supersecure slapd.ServerIdentifier=specdirectory slapd.ServerPort=389 slapd.Suffix=dc=example,dc=com --keepcache General.AdminDomain=#{os_facts[:domain]} General.ConfigDirectoryAdminID=admin General.ConfigDirectoryAdminPwd=supersecure admin.Port=9830 admin.ServerAdminID=admin admin.ServerAdminPwd=supersecure admin.ServerIpAddress=\"127.0.0.1\" admin.SysUser=dirsrv", # rubocop:disable LineLength
               'path'    => '/usr/sbin:/usr/bin:/sbin:/bin',
               'creates' => '/etc/dirsrv/slapd-specdirectory',
             )
@@ -658,7 +658,7 @@ describe 'ds_389::instance' do
           when 'Debian'
             it {
               is_expected.to contain_exec('setup ds: specdirectory').with(
-                'command' => "setup-ds-admin --silent General.FullMachineName=foo.example.com General.SuiteSpotGroup=custom_group General.SuiteSpotUserID=custom_user slapd.InstallLdifFile=none slapd.RootDN=\"cn=Directory Manager\" slapd.RootDNPwd=supersecure slapd.ServerIdentifier=specdirectory slapd.ServerPort=389 slapd.Suffix=dc=example,dc=com --keepcache General.AdminDomain=#{os_facts[:domain]} General.ConfigDirectoryAdminID=admin General.ConfigDirectoryAdminPwd=supersecure admin.Port=9830 admin.ServerAdminID=admin admin.ServerAdminPwd=supersecure admin.ServerIpAddress=\"127.0.0.1\" admin.SysUser=custom_user", # rubocop:disable LineLength
+                'command' => "setup-ds-admin --silent General.FullMachineName=foo.example.com General.SuiteSpotGroup=custom_group General.SuiteSpotUserID=custom_user slapd.AddOrgEntries=Yes slapd.AddSampleEntries=No slapd.InstallLdifFile=suggest slapd.RootDN=\"cn=Directory Manager\" slapd.RootDNPwd=supersecure slapd.ServerIdentifier=specdirectory slapd.ServerPort=389 slapd.Suffix=dc=example,dc=com --keepcache General.AdminDomain=#{os_facts[:domain]} General.ConfigDirectoryAdminID=admin General.ConfigDirectoryAdminPwd=supersecure admin.Port=9830 admin.ServerAdminID=admin admin.ServerAdminPwd=supersecure admin.ServerIpAddress=\"127.0.0.1\" admin.SysUser=custom_user", # rubocop:disable LineLength
                 'path'    => '/usr/sbin:/usr/bin:/sbin:/bin',
                 'creates' => '/etc/dirsrv/slapd-specdirectory',
               )
@@ -675,7 +675,7 @@ describe 'ds_389::instance' do
           when 'RedHat'
             it {
               is_expected.to contain_exec('setup ds: specdirectory').with(
-                'command' => "setup-ds-admin.pl --silent General.FullMachineName=foo.example.com General.SuiteSpotGroup=custom_group General.SuiteSpotUserID=custom_user slapd.InstallLdifFile=none slapd.RootDN=\"cn=Directory Manager\" slapd.RootDNPwd=supersecure slapd.ServerIdentifier=specdirectory slapd.ServerPort=389 slapd.Suffix=dc=example,dc=com --keepcache General.AdminDomain=#{os_facts[:domain]} General.ConfigDirectoryAdminID=admin General.ConfigDirectoryAdminPwd=supersecure admin.Port=9830 admin.ServerAdminID=admin admin.ServerAdminPwd=supersecure admin.ServerIpAddress=\"127.0.0.1\" admin.SysUser=custom_user", # rubocop:disable LineLength
+                'command' => "setup-ds-admin.pl --silent General.FullMachineName=foo.example.com General.SuiteSpotGroup=custom_group General.SuiteSpotUserID=custom_user slapd.AddOrgEntries=Yes slapd.AddSampleEntries=No slapd.InstallLdifFile=suggest slapd.RootDN=\"cn=Directory Manager\" slapd.RootDNPwd=supersecure slapd.ServerIdentifier=specdirectory slapd.ServerPort=389 slapd.Suffix=dc=example,dc=com --keepcache General.AdminDomain=#{os_facts[:domain]} General.ConfigDirectoryAdminID=admin General.ConfigDirectoryAdminPwd=supersecure admin.Port=9830 admin.ServerAdminID=admin admin.ServerAdminPwd=supersecure admin.ServerIpAddress=\"127.0.0.1\" admin.SysUser=custom_user", # rubocop:disable LineLength
                 'path'    => '/usr/sbin:/usr/bin:/sbin:/bin',
                 'creates' => '/etc/dirsrv/slapd-specdirectory',
               )
@@ -743,7 +743,7 @@ describe 'ds_389::instance' do
         when 'Debian'
           it {
             is_expected.to contain_exec('setup ds: ldap01').with(
-              'command' => "setup-ds-admin --silent General.FullMachineName=ldap.test.org General.SuiteSpotGroup=custom_group General.SuiteSpotUserID=custom_user slapd.InstallLdifFile=none slapd.RootDN=\"cn=Directory Manager\" slapd.RootDNPwd=supersecure slapd.ServerIdentifier=ldap01 slapd.ServerPort=1389 slapd.Suffix=dc=test,dc=org --keepcache General.AdminDomain=#{os_facts[:domain]} General.ConfigDirectoryAdminID=admin General.ConfigDirectoryAdminPwd=supersecure admin.Port=9830 admin.ServerAdminID=admin admin.ServerAdminPwd=supersecure admin.ServerIpAddress=\"127.0.0.1\" admin.SysUser=custom_user", # rubocop:disable LineLength
+              'command' => "setup-ds-admin --silent General.FullMachineName=ldap.test.org General.SuiteSpotGroup=custom_group General.SuiteSpotUserID=custom_user slapd.AddOrgEntries=Yes slapd.AddSampleEntries=No slapd.InstallLdifFile=suggest slapd.RootDN=\"cn=Directory Manager\" slapd.RootDNPwd=supersecure slapd.ServerIdentifier=ldap01 slapd.ServerPort=1389 slapd.Suffix=dc=test,dc=org --keepcache General.AdminDomain=#{os_facts[:domain]} General.ConfigDirectoryAdminID=admin General.ConfigDirectoryAdminPwd=supersecure admin.Port=9830 admin.ServerAdminID=admin admin.ServerAdminPwd=supersecure admin.ServerIpAddress=\"127.0.0.1\" admin.SysUser=custom_user", # rubocop:disable LineLength
               'path'    => '/usr/sbin:/usr/bin:/sbin:/bin',
               'creates' => '/etc/dirsrv/slapd-ldap01',
             )
@@ -794,7 +794,7 @@ describe 'ds_389::instance' do
         when 'RedHat'
           it {
             is_expected.to contain_exec('setup ds: ldap01').with(
-              'command' => "setup-ds-admin.pl --silent General.FullMachineName=ldap.test.org General.SuiteSpotGroup=custom_group General.SuiteSpotUserID=custom_user slapd.InstallLdifFile=none slapd.RootDN=\"cn=Directory Manager\" slapd.RootDNPwd=supersecure slapd.ServerIdentifier=ldap01 slapd.ServerPort=1389 slapd.Suffix=dc=test,dc=org --keepcache General.AdminDomain=#{os_facts[:domain]} General.ConfigDirectoryAdminID=admin General.ConfigDirectoryAdminPwd=supersecure admin.Port=9830 admin.ServerAdminID=admin admin.ServerAdminPwd=supersecure admin.ServerIpAddress=\"127.0.0.1\" admin.SysUser=custom_user", # rubocop:disable LineLength
+              'command' => "setup-ds-admin.pl --silent General.FullMachineName=ldap.test.org General.SuiteSpotGroup=custom_group General.SuiteSpotUserID=custom_user slapd.AddOrgEntries=Yes slapd.AddSampleEntries=No slapd.InstallLdifFile=suggest slapd.RootDN=\"cn=Directory Manager\" slapd.RootDNPwd=supersecure slapd.ServerIdentifier=ldap01 slapd.ServerPort=1389 slapd.Suffix=dc=test,dc=org --keepcache General.AdminDomain=#{os_facts[:domain]} General.ConfigDirectoryAdminID=admin General.ConfigDirectoryAdminPwd=supersecure admin.Port=9830 admin.ServerAdminID=admin admin.ServerAdminPwd=supersecure admin.ServerIpAddress=\"127.0.0.1\" admin.SysUser=custom_user", # rubocop:disable LineLength
               'path'    => '/usr/sbin:/usr/bin:/sbin:/bin',
               'creates' => '/etc/dirsrv/slapd-ldap01',
             )


### PR DESCRIPTION
## Issue
* https://github.com/spacepants/puppet-ds_389/issues/18

## Solution
* Added the following options to setup ds
```
slapd.AddOrgEntries=Yes slapd.AddSampleEntries=No slapd.InstallLdifFile=suggest
```
